### PR TITLE
Filter invalid XML response characters before parsing, and hard-fail parse errors.

### DIFF
--- a/lib/ews/exceptions/exceptions.rb
+++ b/lib/ews/exceptions/exceptions.rb
@@ -58,4 +58,7 @@ module Viewpoint::EWS
 
   class EwsSendItemError < EwsError; end
 
+  # Failed SOAP envelope parsing
+  class EwsParseError < EwsError; end
+
 end # Viewpoint::EWS

--- a/lib/ews/soap/parsers/ews_sax_document.rb
+++ b/lib/ews/soap/parsers/ews_sax_document.rb
@@ -66,5 +66,8 @@ module Viewpoint::EWS::SOAP
       end
     end
 
+    def error(message)
+      raise EwsParseError, "Error parsing SAX document: #{message}"
+    end
   end
 end

--- a/spec/soap_data/find_folder_malformed_response.xml
+++ b/spec/soap_data/find_folder_malformed_response.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" 
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+               xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Header>
+    <t:ServerVersionInfo MajorVersion="8" MinorVersion="0" MajorBuildNumber="652" MinorBuildNumber="0" 
+                         xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" />
+  </soap:Header>
+  <soap:Body>
+    <FindFolderResponse xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages" 
+                        xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" 
+                        xmlns="http://schemas.microsoft.com/exchange/services/2006/messages">
+      <m:ResponseMessages>
+        <m:FindFolderResponseMessage ResponseClass="Success">
+          <m:ResponseCode>NoError</m:ResponseCode>
+          <m:RootFolder TotalItemsInView="1" IncludesLastItemInRange="true">
+            <t:Folders>
+              <t:Folder>
+                <t:FolderId Id="AQAnAH" ChangeKey="AQAAABY" />
+                <t:DisplayName>DING!</t:DisplayName>
+                <t:TotalCount>0</t:TotalCount>
+                <t:ChildFolderCount>0</t:ChildFolderCount>
+                <t:UnreadCount>0</t:UnreadCount>
+              </t:Folder>
+            </t:Folders>
+          </m:RootFolder>
+        </m:FindFolderResponseMessage>
+      </m:ResponseMessages>
+    </FindFolderResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/unit/ews_parser_spec.rb
+++ b/spec/unit/ews_parser_spec.rb
@@ -5,6 +5,11 @@ describe "Exchange Response Parser Functionality" do
   let(:success_body) {
     [{:find_folder_response=>{:elems=>[{:response_messages=>{:elems=>[{:find_folder_response_message=>{:attribs=>{:response_class=>"Success"}, :elems=>{:response_code=>{:text=>"NoError"}, :root_folder=>{:attribs=>{:total_items_in_view=>"1", :includes_last_item_in_range=>"true"}, :elems=>[{:folders=>{:elems=>[{:folder=>{:elems=>[{:folder_id=>{:attribs=>{:id=>"AQAnAH", :change_key=>"AQAAABY"}}}, {:display_name=>{:text=>"TestFolder"}}, {:total_count=>{:text=>"0"}}, {:child_folder_count=>{:text=>"0"}}, {:unread_count=>{:text=>"0"}}]}}]}}]}}}}]}}]}}]
   }
+
+  let(:success_body_malformed) {
+    [{:find_folder_response=>{:elems=>[{:response_messages=>{:elems=>[{:find_folder_response_message=>{:attribs=>{:response_class=>"Success"}, :elems=>{:response_code=>{:text=>"NoError"}, :root_folder=>{:attribs=>{:total_items_in_view=>"1", :includes_last_item_in_range=>"true"}, :elems=>[{:folders=>{:elems=>[{:folder=>{:elems=>[{:folder_id=>{:attribs=>{:id=>"AQAnAH", :change_key=>"AQAAABY"}}}, {:display_name=>{:text=>"DING!\uFFFD"}}, {:total_count=>{:text=>"0"}}, {:child_folder_count=>{:text=>"0"}}, {:unread_count=>{:text=>"0"}}]}}]}}]}}}}]}}]}}]
+  }
+
   let(:error_body) {
     [{:find_folder_response=>{:elems=>[{:response_messages=>{:elems=>[{:find_folder_response_message=>{:attribs=>{:response_class=>"Error"}, :elems=>{:message_text=>{:text=>"Id is malformed."}, :response_code=>{:text=>"ErrorInvalidIdMalformed"}, :descriptive_link_key=>{:text=>"0"}}}}]}}]}}]
   }
@@ -13,6 +18,12 @@ describe "Exchange Response Parser Functionality" do
     soap_resp = load_soap 'find_folder', :response
     resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse
     resp.body.should == success_body
+  end
+
+  it 'parses a successful response, even if it contains invalid characters' do
+    soap_resp = load_soap 'find_folder_malformed', :response
+    resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse
+    resp.body.should == success_body_malformed
   end
 
   it 'parses an unsuccessful response' do


### PR DESCRIPTION
Fixes https://github.com/getoutreach/outreach-issues/issues/1464
