### PR TITLE
Handle ews response body empty

### DIFF
--- a/lib/ews/soap/ews_response.rb
+++ b/lib/ews/soap/ews_response.rb
@@ -40,18 +40,20 @@ module Viewpoint::EWS::SOAP
     end
 
     def response
-      body[0]
+      body && body[0]
     end
 
     def response_messages
       return @response_messages if @response_messages
 
       @response_messages = []
-      response_type = response.keys.first
-      response[response_type][:elems][0][:response_messages][:elems].each do |rm|
-        response_message_type = rm.keys[0]
-        rm_klass = class_by_name(response_message_type)
-        @response_messages << rm_klass.new(rm)
+      unless response.nil?
+        response_type = response.keys.first
+        response[response_type][:elems][0][:response_messages][:elems].each do |rm|
+          response_message_type = rm.keys[0]
+          rm_klass = class_by_name(response_message_type)
+          @response_messages << rm_klass.new(rm)
+        end
       end
       @response_messages
     end
@@ -61,6 +63,7 @@ module Viewpoint::EWS::SOAP
 
 
     def simplify!
+      return if response.nil?
       response_type = response.keys.first
       response[response_type][:elems][0][:response_messages][:elems].each do |rm|
         key = rm.keys.first

--- a/lib/ews/soap/exchange_web_service.rb
+++ b/lib/ews/soap/exchange_web_service.rb
@@ -219,10 +219,8 @@ module Viewpoint::EWS::SOAP
       raise EwsError, "Can't parse an empty response. Please check your endpoint." if(soapmsg.nil?)
       opts[:response_class] ||= EwsSoapResponse
       EwsParser.new(soapmsg).parse(opts)
-    rescue Exception => e
-      @log.error "Error parsing soap response:"
-      @log.error soapmsg
-      @log.error e
+    rescue => e
+      @log.warn(message: 'Error parsing soap response', error: e, soap_response: soapmsg)
       raise e
     end
 


### PR DESCRIPTION
[ETOH-1891](https://outreach-io.atlassian.net/browse/ETOH-1891)

Handle the ews response have empty body. Hopefully this won't trigger
failures downstream - I checked and am reasonably confident. But you
never know...

Also tuned down their logging to be more friendly to our Kibana.