### PR TITLE
Fix parsing empty SOAP response body

### DIFF
--- a/lib/ews/soap/ews_soap_response.rb
+++ b/lib/ews/soap/ews_soap_response.rb
@@ -40,26 +40,28 @@ module Viewpoint::EWS::SOAP
     end
 
     def response
-      body[0]
+      body && body[0]
     end
 
     def response_messages
+      return [] if response.nil?
       key = response.keys.first
       response[key][:elems].find{|e| e.keys.include? :response_messages }[:response_messages][:elems]
     end
 
     def response_message
+      return {} if response_messages.empty?
       key = response_messages[0].keys.first
       response_messages[0][key]
     end
 
     def response_class
-      response_message[:attribs][:response_class]
+      guard_hash response_message[:attribs], [:response_class]
     end
     alias :status :response_class
 
     def response_code
-      response_message[:elems][:response_code][:text]
+      guard_hash response_message[:elems], [:response_code, :text]
     end
     alias :code :response_code
 

--- a/spec/soap_data/empty_body_response.xml
+++ b/spec/soap_data/empty_body_response.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Header>
+    <h:ServerVersionInfo MajorVersion="14" MinorVersion="3" MajorBuildNumber="339" MinorBuildNumber="0" Version="Exchange2010_SP2" xmlns:h="http://schemas.microsoft.com/exchange/services/2006/types" xmlns="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"/>
+  </s:Header>
+  <s:Body xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema"/>
+</s:Envelope>

--- a/spec/unit/ews_parser_spec.rb
+++ b/spec/unit/ews_parser_spec.rb
@@ -38,4 +38,12 @@ describe "Exchange Response Parser Functionality" do
     expect(resp.envelope).to_not be_empty
   end
 
+  it 'parses an empty body' do
+    soap_resp = load_soap 'empty_body', :response
+    resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse
+    expect(resp).to_not be_success
+    expect(resp.response_code).to be nil
+    expect(resp.response_message_text).to be nil
+  end
+
 end


### PR DESCRIPTION
Found another place that needs to deal with empty body https://kibana.outreach-internal.com/app/kibana#/doc/logstash-*/logstash-datalog-2017.10.30/outreach-app/?id=AV9u2PHwknCFJq97IdPn