### PR TITLE
Update calendar item correctly

### DIFF
--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -1340,8 +1340,13 @@ module Viewpoint::EWS::SOAP
 
     # Insert item, enforce xmlns attribute if prefix is present
     def dispatch_field_item!(item, ns_prefix = nil)
-      item.values.first[:xmlns_attribute] = ns_prefix if ns_prefix
-      build_xml!(item)
+      # for now, handle calendar_item specially
+      if item.keys.first == :calendar_item
+        send(:calendar_item!, item[:calendar_item])
+      else
+        item.values.first[:xmlns_attribute] = ns_prefix if ns_prefix
+        build_xml!(item)
+      end
     end
 
     def room_list!(cfg_prop)

--- a/spec/ews/types/calendar_item_spec.rb
+++ b/spec/ews/types/calendar_item_spec.rb
@@ -11,4 +11,63 @@ describe Viewpoint::EWS::Types::CalendarItem do
     end
   end
 
+  describe '#derive_item_updates' do
+    let(:item) { described_class.new(nil, {item_id: {attribs: {id: 'not_used'}}}) }
+    subject { item.derive_item_updates(updates) }
+
+    context 'update attribute is invalid' do
+      let(:updates) { {not_valid: 'foo'} }
+
+      it 'returns correct updates' do
+        expect(subject).to eq([])
+      end
+    end
+
+    context 'update subject' do
+      let(:updates) { {subject: 'new subejct'} }
+
+      it 'returns correct updates' do
+        expect(subject).to match_array([
+          {:set_item_field=>{:field_uRI=>{:field_uRI=>"item:Subject"}, :calendar_item=>{:subject=>"new subejct"}}}
+        ])
+      end
+    end
+
+    context 'update start' do
+      let(:updates) { {start: DateTime.new(2018, 1, 1, 8, 0, 0)} }
+
+      it 'returns correct updates' do
+        expect(subject).to match_array([
+          {:set_item_field=>{:field_uRI=>{:field_uRI=>"calendar:Start"}, :calendar_item=>{:start=>{:text=>"2018-01-01T08:00:00+00:00"}}}}
+        ])
+      end
+    end
+
+    context 'update required attendees' do
+      let(:updates) { {required_attendees: {attendee: {mailbox: {email_address: 'a@foo.com'}}}} }
+
+      it 'returns correct updates' do
+        expect(subject).to match_array([
+          {:set_item_field=>{:field_uRI=>{:field_uRI=>"calendar:RequiredAttendees"}, :calendar_item=>{:required_attendees=>{:attendee=>{:mailbox=>{:email_address=>"a@foo.com"}}}}}}
+        ])
+      end
+    end
+
+    context 'compound updates' do
+      let(:updates) do
+        {
+          not_valid: 'foo',
+          location: nil,
+          body: 'foo body'
+        }
+      end
+
+      it 'returns correct updates' do
+        expect(subject).to match_array([
+          {:delete_item_field=>{:field_uRI=>{:field_uRI=>"calendar:Location"}}},
+          {:set_item_field=>{:field_uRI=>{:field_uRI=>"item:Body"}, :calendar_item=>{:body=>{:body_type=>"Text", :text=>"foo body"}}}}
+        ])
+      end
+    end
+  end
 end


### PR DESCRIPTION
Update calendar item was not generating required_attendees structure
correctly, since it was using `build_xml!`, which requires annoying
`sub_elements` in a lot of places. But the ews_builder actually have
`calendar_item!` method already (which is used in the `create_item`, but
not `update_item` - not entirely sure why).

This is a minimal change to directly use `calendar_item!` instead of
unintuitive `build_xml!` for updates too.