### PR TITLE
Parses fault without header correctly

### DIFF
--- a/lib/ews/soap/ews_soap_response.rb
+++ b/lib/ews/soap/ews_soap_response.rb
@@ -32,11 +32,13 @@ module Viewpoint::EWS::SOAP
     end
 
     def header
-      envelope[0][:header][:elems]
+      header_entry = envelope.find { |e| e.key?(:header) }
+      header_entry[:header][:elems] if header_entry
     end
 
     def body
-      envelope[1][:body][:elems]
+      body_entry = envelope.find { |e| e.key?(:body) }
+      body_entry[:body][:elems] if body_entry
     end
 
     def response
@@ -46,7 +48,8 @@ module Viewpoint::EWS::SOAP
     def response_messages
       return [] if response.nil?
       key = response.keys.first
-      response[key][:elems].find{|e| e.keys.include? :response_messages }[:response_messages][:elems]
+      response_messages_entry = response[key][:elems].find{ |e| e.key?(:response_messages) }
+      response_messages_entry ? response_messages_entry[:response_messages][:elems] : []
     end
 
     def response_message

--- a/spec/soap_data/fault_no_header_response.xml
+++ b/spec/soap_data/fault_no_header_response.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">
+  <s:Body>
+    <s:Fault>
+      <faultcode xmlns:a="http://schemas.microsoft.com/exchange/services/2006/types">a:ErrorExceededConnectionCount</faultcode>
+      <faultstring xml:lang="en-US">You have exceeded the available concurrent connections for your account.  Try again once your other requests have completed.</faultstring>
+      <detail>
+        <e:ResponseCode xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">ErrorExceededConnectionCount</e:ResponseCode>
+        <e:Message xmlns:e="http://schemas.microsoft.com/exchange/services/2006/errors">You have exceeded the available concurrent connections for your account.  Try again once your other requests have completed.</e:Message>
+      </detail>
+    </s:Fault>
+  </s:Body>
+</s:Envelope>

--- a/spec/unit/ews_parser_spec.rb
+++ b/spec/unit/ews_parser_spec.rb
@@ -38,12 +38,33 @@ describe "Exchange Response Parser Functionality" do
     expect(resp.envelope).to_not be_empty
   end
 
+  it 'parses with EwsResponse' do
+    soap_resp = load_soap 'get_item_bad_character', :response
+    resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse(response_class: Viewpoint::EWS::SOAP::EwsResponse)
+    expect(resp.response_messages[0].items).to_not be_empty
+  end
+
   it 'parses an empty body' do
     soap_resp = load_soap 'empty_body', :response
     resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse
     expect(resp).to_not be_success
     expect(resp.response_code).to be nil
     expect(resp.response_message_text).to be nil
+  end
+
+  it 'parses fault without header' do
+    soap_resp = load_soap 'fault_no_header', :response
+    resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse
+    expect(resp).to_not be_success
+    expect(resp.header).to be nil
+    expect(resp.response_messages).to be_empty
+  end
+
+  it 'parses fault without header using EwsResponse' do
+    soap_resp = load_soap 'fault_no_header', :response
+    resp = Viewpoint::EWS::SOAP::EwsParser.new(soap_resp).parse(response_class: Viewpoint::EWS::SOAP::EwsResponse)
+    expect(resp.header).to be nil
+    expect(resp.response_messages).to be_empty
   end
 
 end


### PR DESCRIPTION
[ETOH-2100](https://outreach-io.atlassian.net/browse/ETOH-2100)

EWS soap response can sometimes be a fault and without header. Parser
should not blow up by this.