### PR TITLE
Revert "Optimize sax document string concat"

### DIFF
--- a/lib/ews/soap/parsers/ews_sax_document.rb
+++ b/lib/ews/soap/parsers/ews_sax_document.rb
@@ -38,7 +38,7 @@ module Viewpoint::EWS::SOAP
       #string.strip!
       return if string.empty?
       if @elems.last[:text]
-        @elems.last[:text] << string
+        @elems.last[:text] += string
       else
         @elems.last[:text] = string
       end


### PR DESCRIPTION
It looks like the reverted commit is trying to optimize the memory usage of a string concatenation.

This seems like it can actually cause some _really_ weird bugs. The result of the characters method is fed directly into the libxml2 c extension. Using a `<<` instead of a `+=` makes Ruby change the actual object in place, which seems like it could create some race conditions with the c extension if they are both referencing the same item in memory. https://medium.com/@AdamLombard/easy-ruby-plus-equals-vs-shovel-6f030875e366

Looking at a [benchmark](https://stackoverflow.com/questions/4684446/why-is-the-shovel-operator-preferred-over-plus-equals-when-building-a) on stack overflow it looks like this could in the absolute worst case make parsing 2x slower. Considering we're mostly network bound, this should be fine. 