### PR TITLE
Allow swapping out `HTTPClient` class

### DIFF
--- a/lib/ews/connection.rb
+++ b/lib/ews/connection.rb
@@ -33,7 +33,8 @@ class Viewpoint::EWS::Connection
   # @option opts [Fixnum] :send_timeout override the default send timeout
   def initialize(endpoint, opts = {})
     @log = Logging.logger[self.class.name.to_s.to_sym]
-    @httpcli = HTTPClient.new
+    @httpcli = (opts[:httpclient_class] || HTTPClient).new
+
     if opts[:trust_ca]
       @httpcli.ssl_config.clear_cert_store
       opts[:trust_ca].each do |ca|


### PR DESCRIPTION
Previous changes to this library allowed swapping out the
`Viewpoint::EWS::Connection` class, but so far the use of the HTTPClient
was directly hard-coded into the default `Connection` class.

This change will make it easier to swap in alternative implementations
of HTTPClient without having to swap out the `Connection` class.