### PR TITLE
[CMS-224] Added support for ContainsRecipientStrings.

### DIFF
--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -608,6 +608,14 @@ module Viewpoint::EWS::SOAP
       }
     end
 
+    def contains_recipients(expr)
+      @nbuild[NS_EWS_TYPES].ContainsRecipientStrings() {
+        expr.delete(:recipients).each do |recipient|
+          nbuild[NS_EWS_TYPES].String recipient
+        end
+      }
+    end
+
     def excludes(expr)
       @nbuild[NS_EWS_TYPES].Excludes {
         b = expr.delete(:bitmask) # remove bitmask 1st for ordering

--- a/spec/ews/soap/ews_builder_spec.rb
+++ b/spec/ews/soap/ews_builder_spec.rb
@@ -1,0 +1,48 @@
+require "spec_helper"
+
+describe Viewpoint::EWS::SOAP::EwsBuilder do
+  describe "#build!" do
+    let(:builder) { described_class.new }
+
+    it "creates a basic XML" do
+      opts = { :server_version => '1.2.3', :impersonation_type => 'type', :impersonation_mail => 'abc@xyz' }
+      default_ns = Viewpoint::EWS::SOAP::NAMESPACES["xmlns:#{Viewpoint::EWS::SOAP::NS_EWS_MESSAGES}"]
+      shape = {
+        :base_shape => :id_only
+      }
+      parent_folder_ids = [{:id => 'parent-folder-id'}]
+      restriction = {or: [
+        {
+          :contains => {
+            :containment_mode => 'Substring',
+            :containment_comparison => 'IgnoreCase',
+            :field_uRI => {:field_uRI => 'f' },
+            :constant => {:value => 'some-value' }
+          }
+        },
+        {
+          :contains_recipients => {
+            :recipients => ['abc@def.cz', 'ghi@jkl.ch']
+          }
+        }
+      ]}
+
+      req = builder.build!(opts) do |type, builder|
+        if(type == :header)
+        else
+          builder.nbuild.FindItem(:Traversal => 'Shalow') {
+            builder.nbuild.parent.default_namespace = default_ns
+            builder.item_shape!(shape)
+            builder.restriction!(restriction)
+            builder.parent_folder_ids!(parent_folder_ids)
+          }
+        end
+      end
+
+      expected_response = load_soap 'find_item', :request
+      expected_response = Nokogiri.XML(expected_response).to_xml
+      expect(req.to_xml).to eq(expected_response)
+    end
+
+  end
+end

--- a/spec/soap_data/find_item_request.xml
+++ b/spec/soap_data/find_item_request.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:t="http://schemas.microsoft.com/exchange/services/2006/types" xmlns:m="http://schemas.microsoft.com/exchange/services/2006/messages">
+  <soap:Header>
+    <t:RequestServerVersion Version="1.2.3"/>
+    <t:ExchangeImpersonation>
+      <t:ConnectingSID>
+        <t:type>abc@xyz</t:type>
+      </t:ConnectingSID>
+    </t:ExchangeImpersonation>
+  </soap:Header>
+  <soap:Body>
+    <FindItem xmlns="http://schemas.microsoft.com/exchange/services/2006/messages" Traversal="Shalow">
+      <ItemShape>
+        <t:BaseShape>IdOnly</t:BaseShape>
+      </ItemShape>
+      <m:Restriction>
+        <t:Or>
+          <t:Contains ContainmentMode="Substring" ContainmentComparison="IgnoreCase">
+            <t:FieldURI FieldURI="f"/>
+            <t:Constant Value="some-value"/>
+          </t:Contains>
+          <t:ContainsRecipientStrings>
+            <t:String>abc@def.cz</t:String>
+            <t:String>ghi@jkl.ch</t:String>
+          </t:ContainsRecipientStrings>
+        </t:Or>
+      </m:Restriction>
+      <m:ParentFolderIds>
+        <t:FolderId Id="parent-folder-id"/>
+      </m:ParentFolderIds>
+    </FindItem>
+  </soap:Body>
+</soap:Envelope>


### PR DESCRIPTION
This PR adds support for ContainsRecipientStrings tag described in:
https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/containsrecipientstrings

This is an alternative to tags ToRecipients and CcRecipients.

This will be used in a subsequent PR for Flagship.

[JIRA-CMS-224]