### PR TITLE
[CMS-276] Fix the namespace of <Restriction> tag

### DIFF
--- a/lib/ews/soap/builders/ews_builder.rb
+++ b/lib/ews/soap/builders/ews_builder.rb
@@ -566,7 +566,7 @@ module Viewpoint::EWS::SOAP
     # @see http://msdn.microsoft.com/en-us/library/aa563791.aspx
     # @param [Hash] restriction a well-formatted Hash that can be fed to #build_xml!
     def restriction!(restriction)
-      @nbuild[NS_EWS_MESSAGES].Restriction {
+      @nbuild[NS_EWS_TYPES].Restriction {
         restriction.each_pair do |k,v|
           self.send normalize_type(k), v
         end

--- a/spec/soap_data/find_folder_request.xml
+++ b/spec/soap_data/find_folder_request.xml
@@ -8,14 +8,14 @@
       <FolderShape>
         <t:BaseShape>Default</t:BaseShape>
       </FolderShape>
-      <m:Restriction>
+      <t:Restriction>
         <t:IsEqualTo>
           <t:FieldURI FieldURI="folder:DisplayName"/>
           <t:FieldURIOrConstant>
             <t:Constant Value="Test Folder"/>
           </t:FieldURIOrConstant>
         </t:IsEqualTo>
-      </m:Restriction>
+      </t:Restriction>
       <m:ParentFolderIds>
         <t:DistinguishedFolderId Id="msgfolderroot"/>
       </m:ParentFolderIds>

--- a/spec/soap_data/find_item_request.xml
+++ b/spec/soap_data/find_item_request.xml
@@ -13,7 +13,7 @@
       <ItemShape>
         <t:BaseShape>IdOnly</t:BaseShape>
       </ItemShape>
-      <m:Restriction>
+      <t:Restriction>
         <t:Or>
           <t:Contains ContainmentMode="Substring" ContainmentComparison="IgnoreCase">
             <t:FieldURI FieldURI="f"/>
@@ -24,7 +24,7 @@
             <t:String>ghi@jkl.ch</t:String>
           </t:ContainsRecipientStrings>
         </t:Or>
-      </m:Restriction>
+      </t:Restriction>
       <m:ParentFolderIds>
         <t:FolderId Id="parent-folder-id"/>
       </m:ParentFolderIds>


### PR DESCRIPTION
According to the documentation, the <Restriction> tag should be in the
https://schemas.microsoft.com/exchange/services/2006/types namespace,
not https://schemas.microsoft.com/exchange/services/2006/messages (see
https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/restriction
for details).
    
This + another small fix in the flagship code fixes the sync issue.
    
TESTED=bundle exec rspec spec/ews/soap/ews_builder_spec.rb